### PR TITLE
Extend grace period to unknown status too

### DIFF
--- a/src/SponsorLink/Analyzer/StatusReportingAnalyzer.cs
+++ b/src/SponsorLink/Analyzer/StatusReportingAnalyzer.cs
@@ -14,14 +14,14 @@ namespace Analyzer;
 public class StatusReportingAnalyzer : DiagnosticAnalyzer
 {
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(new DiagnosticDescriptor(
-        "SL001", "Report Sponsoring Status", "Reports sponsoring status determined by SponsorLink", "Sponsors", 
+        "SL001", "Report Sponsoring Status", "Reports sponsoring status determined by SponsorLink", "Sponsors",
         DiagnosticSeverity.Warning, true));
 
     public override void Initialize(AnalysisContext context)
     {
         context.EnableConcurrentExecution();
         context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
-        
+
         context.RegisterCompilationAction(c =>
         {
             var installed = c.Options.AdditionalFiles.Where(x =>

--- a/src/SponsorLink/SponsorLink.targets
+++ b/src/SponsorLink/SponsorLink.targets
@@ -16,8 +16,8 @@
     <FundingProduct Condition="'$(FundingProduct)' == ''">$(Product)</FundingProduct>
     <!-- Default prefix is the joined upper-case letters in the product name (i.e. for ThisAssembly, TA) -->
     <FundingPrefix Condition="'$(FundingPrefix)' == ''">$([System.Text.RegularExpressions.Regex]::Replace("$(FundingProduct)", "[^A-Z]", ""))</FundingPrefix>
-    <!-- Default grace days for an expired sponsor manifest -->
-    <FundingGrace Condition="'$(FundingGrace)' == ''">21</FundingGrace>
+    <!-- Default grace days for an expired sponsor manifest or unknown status -->
+    <FundingGrace Condition="'$(FundingGrace)' == ''">15</FundingGrace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SponsorLink/SponsorLink/SponsorLink.cs
+++ b/src/SponsorLink/SponsorLink/SponsorLink.cs
@@ -88,7 +88,7 @@ static partial class SponsorLink
             if (Validate(value.jwt, value.jwk, out var token, out var identity, false) == ManifestStatus.Valid && identity != null)
             {
                 if (principal == null)
-                    principal = new(identity);
+                    principal = new JwtRolesPrincipal(identity);
                 else
                     principal.AddIdentity(identity);
             }
@@ -158,7 +158,7 @@ static partial class SponsorLink
         }
 
         token = result.SecurityToken;
-        identity = new ClaimsIdentity(result.ClaimsIdentity.Claims);
+        identity = new ClaimsIdentity(result.ClaimsIdentity.Claims, "JWT");
 
         if (validateExpiration && token.ValidTo == DateTime.MinValue)
             return ManifestStatus.Invalid;
@@ -168,5 +168,10 @@ static partial class SponsorLink
             return ManifestStatus.Expired;
 
         return ManifestStatus.Valid;
+    }
+
+    class JwtRolesPrincipal(ClaimsIdentity identity) : ClaimsPrincipal([identity])
+    {
+        public override bool IsInRole(string role) => HasClaim("roles", role) || base.IsInRole(role);
     }
 }

--- a/src/SponsorLink/Tests/Sample.cs
+++ b/src/SponsorLink/Tests/Sample.cs
@@ -40,7 +40,7 @@ public class Sample(ITestOutputHelper output)
     public void RenderSponsorables()
     {
         Assert.NotEmpty(SponsorLink.Sponsorables);
-        
+
         foreach (var pair in SponsorLink.Sponsorables)
         {
             output.WriteLine($"{pair.Key} = {pair.Value}");

--- a/src/SponsorLink/Tests/SponsorableManifest.cs
+++ b/src/SponsorLink/Tests/SponsorableManifest.cs
@@ -285,7 +285,7 @@ public class SponsorableManifest
             MapInboundClaims = false,
             SetDefaultTimesOnTokenCreation = false,
         }.ValidateTokenAsync(jwt, validation).Result;
-        
+
         token = result.SecurityToken;
         return result.ClaimsIdentity;
     }

--- a/src/SponsorLink/Tests/Tests.csproj
+++ b/src/SponsorLink/Tests/Tests.csproj
@@ -19,7 +19,7 @@
   <ItemGroup>
     <!-- This project reference allows debugging the source generator/analyzer project -->
     <ProjectReference Include="..\Analyzer\Analyzer.csproj" Aliases="Analyzer" />
-    <Analyzer Include="..\Analyzer\bin\$(Configuration)\netstandard2.0\*.dll" NuGetPackageId="SponsorableLib" />
+    <Analyzer Include="..\Analyzer\bin\$(Configuration)\netstandard2.0\*.dll" NuGetPackageId="SponsorableLib" Visible="false" />
   </ItemGroup>
 
   <ItemGroup>
@@ -54,8 +54,15 @@
   <!-- Simulates importing SponsorableLib.targets -->
   <Import Project="..\SponsorLink\buildTransitive\Devlooped.Sponsors.targets" />
   <ItemGroup>
-    <!-- Bring in the analyzer file to report installation time -->
-    <AdditionalFiles Include="@(Analyzer -> WithMetadataValue('NuGetPackageId', 'SponsorableLib'))" />
+    <!-- Brings in the analyzer file to report installation time -->
+    <SponsorablePackageId Include="SponsorableLib" />
   </ItemGroup>
 
+  <!-- Force immediate reporting of status, no install-time grace period -->
+  <PropertyGroup>
+    <SponsorLinkNoInstallGrace>true</SponsorLinkNoInstallGrace>
+  </PropertyGroup>
+  <ItemGroup>
+    <CompilerVisibleProperty Include="SponsorLinkNoInstallGrace" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Use the existing Funding.Grace value also as the value for an install-time (optional) grace period where no warnings will be reported.

In order for the install-time check to be performed, the package must provide an item `SponsorablePackageId` with the package id containing the analyzer.

The install check can be skipped (for testing purposes) by adding a compiler visible property, like so:

```xml
  <!-- Force immediate reporting of status, no install-time grace period -->
  <PropertyGroup>
    <SponsorLinkNoInstallGrace>true</SponsorLinkNoInstallGrace>
  </PropertyGroup>
  <ItemGroup>
    <CompilerVisibleProperty Include="SponsorLinkNoInstallGrace" />
  </ItemGroup>
```

This allows testing the behavior of the unknown status warning right after installing the package.

Note that if no install time can be determined, the unknown status will always be reported.