### PR TITLE
Make sure we report only once per product for entire solution

### DIFF
--- a/src/SponsorLink/Library/Library.csproj
+++ b/src/SponsorLink/Library/Library.csproj
@@ -18,4 +18,8 @@
     <ProjectReference Include="..\Analyzer\Analyzer.csproj" ReferenceOutputAssembly="false" OutputType="Analyzer" />
   </ItemGroup>
 
+  <Target Name="Version" AfterTargets="GetPackageContents" DependsOnTargets="GetPackageTargetPath">
+    <Message Importance="high" Text="$(MSBuildProjectName) &gt; $(PackageTargetPath)" />
+  </Target>
+
 </Project>

--- a/src/SponsorLink/SponsorLink/SponsorLinkAnalyzer.cs
+++ b/src/SponsorLink/SponsorLink/SponsorLinkAnalyzer.cs
@@ -45,7 +45,7 @@ public class SponsorLinkAnalyzer : DiagnosticAnalyzer
                     // NOTE: for multiple projects with the same product name, we only report one diagnostic, 
                     // so it's expected to NOT get a diagnostic back. Also, we don't want to report 
                     // multiple diagnostics for each project in a solution that uses the same product.
-                    if (Diagnostics.Pop(Funding.Product) is Diagnostic diagnostic)
+                    Diagnostics.ReportOnce(diagnostic =>
                     {
                         // For unknown (never sync'ed), only report if install grace period is over
                         if (status == SponsorStatus.Unknown)
@@ -80,7 +80,7 @@ public class SponsorLinkAnalyzer : DiagnosticAnalyzer
                         }
 
                         ctx.ReportDiagnostic(diagnostic);
-                    }
+                    });
                 });
             }
         });


### PR DESCRIPTION
Since many projects can use the same package in a solution, it makes no sense to report multiple times the same diagnostic asking for funding. It would just be super annoying.

So make it process-wide and singleton. We use a mutex+memory-mapped file which lives alongside the whole process, since individual projects may be built separately and cause duplicate reporting even if we use use static or AppDomain-stored state.